### PR TITLE
Add HypoVault explanation

### DIFF
--- a/docs/HypoVault_explanation.md
+++ b/docs/HypoVault_explanation.md
@@ -1,0 +1,127 @@
+# Understanding HypoVault
+
+This document explains `HypoVault.sol` and `PanopticVaultAccountant.sol` at multiple levels of depth. It starts with an "explain like I'm five" (ELI5) overview and gradually moves towards a line‑by‑line discussion, pointing out notable design choices and potential security considerations.
+
+## 1. ELI5 Overview
+
+Imagine a piggy bank (the vault) managed by a trusted manager. People can put their coins (tokens) into this piggy bank and later take them out. The manager handles the coins, invests them, and keeps track of how much everyone should get back. The code ensures that everyone gets their fair share and that the manager follows the rules.
+
+- **Deposits**: Users can request to put tokens in. The request is stored until the manager confirms it.
+- **Withdrawals**: Users can ask to take out some of their share. This request is also stored until the manager confirms it.
+- **Manager actions**: The manager can perform operations to fulfill deposits/withdrawals and manage investments.
+- **Accounting**: An external accountant helps determine how much the vault is worth so that deposits and withdrawals are fair.
+
+## 2. Intermediate Explanation
+
+### Key Concepts
+
+- **Epochs**: Deposits and withdrawals are grouped into periods called epochs. Each epoch records how many assets/shares have been requested and how many have been fulfilled.
+- **Pending queues**: When a user requests a deposit or withdrawal, the request sits in a queue until the manager executes it. Users can also cancel requests before fulfillment.
+- **Performance fee**: When a user withdraws more than they initially put in (profit), a small percentage goes to a fee wallet.
+
+### Main Components
+
+- `HypoVault` (lines 16‑583) is the ERC‑20–like contract that issues vault shares and manages user requests. Key storage variables are defined around lines 135‑173.
+- `PanopticVaultAccountant` (lines 19‑259) calculates the Net Asset Value (NAV) of the vault’s positions. It uses price data and pool information to determine how much the vault is worth.
+
+### Deposits
+
+1. **requestDeposit** (lines 228‑239):
+   - Records the deposit amount in the current epoch.
+   - Transfers tokens from the user to the vault.
+   - Emits `DepositRequested`.
+2. **executeDeposit** (lines 307‑343):
+   - Only allowed for epochs that have been fulfilled (checked at line 311).
+   - Calculates the user’s share of fulfilled assets and mints virtual shares accordingly.
+   - Moves any unfulfilled portion to the next epoch.
+
+### Withdrawals
+
+1. **requestWithdrawal** (lines 242‑267):
+   - Calculates how much of the user’s cost basis should move to pending withdrawal.
+   - Burns the user’s virtual shares immediately.
+2. **executeWithdrawal** (lines 345‑395):
+   - Only allowed for epochs that have been fulfilled (line 349).
+   - Determines how many assets correspond to the user’s portion of the fulfilled withdrawals.
+   - Applies the performance fee and transfers tokens to the user.
+   - Moves any unfulfilled portion to the next epoch.
+
+### Manager Functions
+
+- **fulfillDeposits** (lines 468‑509) and **fulfillWithdrawals** (lines 511‑559) process queued requests based on the NAV reported by the accountant.
+- **manage** functions (lines 444‑466) allow the manager to call arbitrary external contracts from the vault. This is powerful but requires trust in the manager.
+
+## 3. Advanced Walkthrough
+
+Below is a more detailed look at important sections, including potential risks.
+
+### Storage Layout
+
+- `underlyingToken`, `performanceFeeBps`, and other variables (lines 135‑173) store core configuration. `underlyingToken` and `performanceFeeBps` are immutable once set in the constructor (lines 180‑191).
+- `depositEpochState` and `withdrawalEpochState` mappings (lines 159‑163) track how many assets/shares were deposited/withdrawn and how much was fulfilled in each epoch.
+- `queuedDeposit` and `queuedWithdrawal` mappings (lines 165‑170) track per‑user requests.
+
+### Security Considerations
+
+1. **Access Control**
+   - Only the owner can change the manager or accountant (lines 206‑215). The manager controls deposit/withdrawal fulfillment and arbitrary calls, so compromising the manager poses a high risk.
+2. **Re‑entrancy**
+   - Functions like `executeWithdrawal` transfer tokens after modifying state (lines 373‑393). Because these tokens can be arbitrary ERC‑20s, they might contain hooks. However, there is no explicit re‑entrancy guard. The vault relies on the ERC‑20 transfers being well behaved.
+3. **Manage Function**
+   - The `manage` functions (lines 444‑466) let the manager execute arbitrary calls. This design assumes the manager is fully trusted. If the manager’s private key is compromised, funds could be stolen.
+4. **Math Precision**
+   - Calculations use the `Math` library from Panoptic, which uses unchecked math where appropriate. Care is needed to ensure no over/underflow. The contract uses Solidity ^0.8.28, so basic overflow checks are built in unless `unchecked` is used.
+5. **Epoch Logic**
+   - When deposits or withdrawals are partially fulfilled, the remainder is moved to the next epoch (lines 337‑340 and 379‑386). This prevents funds from getting stuck but relies on the manager correctly calling `fulfillDeposits` and `fulfillWithdrawals`.
+
+### Line‑by‑Line Highlights
+
+- **Constructor** (lines 180‑191): Sets initial parameters and mints 1,000,000 bootstrap shares to the contract itself.
+- **onlyManager modifier** (lines 197‑200): Simple check to restrict certain functions.
+- **_transferBasis** (lines 425‑438): Handles cost basis adjustments when users transfer shares, ensuring performance fees are calculated correctly on withdrawal.
+- **fulfillDeposits** (lines 468‑509):
+  - Calculates total assets by calling `accountant.computeNAV` and subtracting unfulfilled deposits and reserved withdrawal assets (lines 480‑483).
+  - Determines how many shares to mint for the fulfilled assets (line 487).
+  - Updates epoch counters and total supply.
+- **fulfillWithdrawals** (lines 511‑559):
+  - Computes NAV similarly and checks that the assets required do not exceed `maxAssetsReceived` (lines 521‑535).
+  - Updates the reserved assets and total supply accordingly.
+
+### PanopticVaultAccountant
+
+- This contract helps compute the value of the vault’s positions. It decodes manager‑provided data (lines 99‑103) and verifies that the provided pool information matches a stored hash (line 105).
+- The loop starting at line 112 iterates over each pool, ensuring oracle prices are close to manager‑provided prices (lines 113‑118). It then aggregates exposures from positions and converts them to the vault’s underlying token.
+- At the end, it sums up positive exposures and adds any leftover underlying token balance (lines 249‑259).
+
+## 4. Potential Vulnerabilities
+
+While the contracts follow common patterns, consider the following:
+
+1. **Trusted Manager**: The vault heavily relies on the manager’s honesty. If the manager calls `manage` to send tokens elsewhere or misreports NAV to the accountant, users could be harmed. Multi‑sig control or timelocks might mitigate this.
+2. **Re‑entrancy via ERC‑20 callbacks**: If the underlying token has hooks on transfer, `executeWithdrawal` could potentially be exploited. A re‑entrancy guard (like OpenZeppelin’s `ReentrancyGuard`) could add protection.
+3. **Oracle Price Manipulation** (Accountant): The accountant checks that oracle prices are within `maxPriceDeviation` of manager prices (lines 113‑118 and 215‑247). If oracles are manipulated or stale, NAV calculations may be wrong, leading to incorrect fulfillment values.
+4. **Arithmetic Rounding**: The code uses `Math.mulDiv` and other helpers which should handle rounding well, but extreme edge cases might cause rounding bias. Thorough unit tests are required.
+
+### Simple ASCII Diagram
+
+```
++------------------+
+| Users            |
++------------------+
+        | requestDeposit / requestWithdrawal
+        v
++------------------+
+| HypoVault        |
++------------------+
+        | fulfillDeposits / fulfillWithdrawals
+        v
++--------------------------+
+| PanopticVaultAccountant  |
++--------------------------+
+```
+This diagram shows how user requests enter the vault, and the manager interacts with the accountant to determine asset values when fulfilling those requests.
+
+## 5. Conclusion
+
+`HypoVault` manages user deposits and withdrawals in epochs, relying on a trusted manager and an accountant contract to value the vault’s assets. Understanding each function’s role—especially deposit/withdrawal queues, manager privileges, and NAV calculation—is crucial for assessing the vault’s security. Potential vulnerabilities mainly revolve around trust in the manager, the safety of token transfers, and the correctness of oracle data.
+


### PR DESCRIPTION
## Summary
- add a `docs/HypoVault_explanation.md` document that walks through the `HypoVault` and `PanopticVaultAccountant` contracts from an ELI5 overview to an advanced discussion with security considerations

## Testing
- `forge test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f72ce7c1083288579d3f7091ed201